### PR TITLE
Update replace failing multiple backslashes

### DIFF
--- a/core.js
+++ b/core.js
@@ -54,7 +54,7 @@ class SiteMapper {
             }
             let fileExtension =  site.split('.').pop().length;
             let fileNameWithoutExtension = site.substring(0, site.length - (fileExtension + 1));
-            let newDir = dir.replace(this.pagesdirectory,'').replace('\\' ,'/');
+            let newDir = dir.replace(this.pagesdirectory,'').replace(/\\/g ,'/');
             let alternates = '';
             for (let langSite in this.alternatesUrls) {
                 alternates += `<xhtml:link rel="alernate" hreflang="${langSite}" href="${


### PR DESCRIPTION
Substantially all the code worked, but the string.replace only replaced the first backslash in cases featuring long paths with multiple ones, just upgraded the lookup to be a regex with a global flag.