### PR TITLE
Added support for calling `exportPathMap` from the `next.config.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ After generating the output files, run `node your_nextjs_sitemap_generator.js` t
       baseUrl: 'https://example.com',  
       ignoredPaths: ['admin'],  
       pagesDirectory: __dirname + "\\pages",  
-      targetDirectory : 'static/'  
+      targetDirectory : 'static/',
+      nextConfigPath: __dirname + "\\next.config.js"
     });
 
 ## OPTIONS description
@@ -38,6 +39,7 @@ After generating the output files, run `node your_nextjs_sitemap_generator.js` t
  - **ignoredPaths**:  File or directory to not map (like admin routes).(OPTIONAL)
  - **pagesDirectory**:  The directory where Nextjs pages live. You can use another directory while they are nextjs pages. **It must to be an absolute path**.
  - **targetDirectory**:  The directory where sitemap.xml going to be written.
+ - **nextConfigPath**:  Calls `exportPathMap` if exported from `nextConfigPath` js file.
 
 ## Considerations
 For now the **ignoredPaths** matches whatever cointaning the thing you put, ignoring if there are files or directories.

--- a/core.js
+++ b/core.js
@@ -1,79 +1,133 @@
-const fs = require('fs');
-const dateFns = require('date-fns');
-const path = require('path');
+const fs = require("fs");
+const dateFns = require("date-fns");
+const path = require("path");
 
 class SiteMapper {
-
-
-    constructor({
-                    alternateUrls,
-                    baseUrl,
-                    ignoreIndexFiles,
-                    ignoredPaths,
-                    pagesDirectory,
-                    sitemapPath,
-                    targetDirectory,
-                }) {
-                    
-        this.alternatesUrls = alternateUrls || {};
-        this.baseUrl = baseUrl;
-        this.ignoredPaths = ignoredPaths || [];
-        this.ignoreIndexFiles = ignoreIndexFiles || false;
-        this.pagesdirectory = pagesDirectory;
-        this.sitemapPath = sitemapPath;
-        this.targetDirectory = targetDirectory;
-        this.sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+  constructor({
+    alternateUrls,
+    baseUrl,
+    ignoreIndexFiles,
+    ignoredPaths,
+    pagesDirectory,
+    sitemapPath,
+    targetDirectory,
+    nextConfigPath
+  }) {
+    this.alternatesUrls = alternateUrls || {};
+    this.baseUrl = baseUrl;
+    this.ignoredPaths = ignoredPaths || [];
+    this.ignoreIndexFiles = ignoreIndexFiles || false;
+    this.pagesdirectory = pagesDirectory;
+    this.sitemapPath = sitemapPath;
+    this.targetDirectory = targetDirectory;
+    this.nextConfigPath = nextConfigPath;
+    this.sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 `;
 
+    if (this.nextConfigPath) {
+      this.nextConfig = require(nextConfigPath);
+    }
+  }
 
+  preLaunch() {
+    fs.writeFileSync(
+      path.resolve(this.targetDirectory, "./sitemap.xml"),
+      this.sitemap,
+      {
+        flag: "w"
+      }
+    );
+  }
+
+  finish() {
+    fs.writeFileSync(
+      path.resolve(this.targetDirectory, "./sitemap.xml"),
+      "</urlset>",
+      {
+        flag: "as"
+      }
+    );
+  }
+
+  /**
+   *
+   */
+  buildPathMap(dir) {
+    var pathMap = {};
+
+    let data = fs.readdirSync(dir);
+    for (let site of data) {
+      // Filter directories
+      if (site[0] === "_" || site[0] === ".") continue;
+      let toIgnore = false;
+      for (let path of this.ignoredPaths) {
+        if (site.includes(path)) toIgnore = true;
+      }
+      if (toIgnore) continue;
+
+      // Handle recursive paths
+      if (fs.lstatSync(dir + path.sep + site).isDirectory()) {
+        pathMap = {
+          ...pathMap,
+          ...this.buildPathMap(dir + path.sep + site)
+        };
+
+        continue;
+      }
+
+      // Is file
+      let fileExtension = site.split(".").pop().length;
+      let fileNameWithoutExtension = site.substring(
+        0,
+        site.length - (fileExtension + 1)
+      );
+      fileNameWithoutExtension =
+        this.ignoreIndexFiles && fileNameWithoutExtension === "index"
+          ? ""
+          : fileNameWithoutExtension;
+      let newDir = dir.replace(this.pagesdirectory, "").replace(/\\/g, "/");
+
+      let pagePath = newDir + "/" + fileNameWithoutExtension;
+      pathMap[pagePath] = {
+        page: pagePath
+      };
     }
 
-    preLaunch() {
-        fs.writeFileSync(`${this.targetDirectory}sitemap.xml`, this.sitemap, {flag: 'w'});
-    };
+    return pathMap;
+  }
 
-    finish() {
-        fs.writeFileSync(`${this.targetDirectory}sitemap.xml`, '</urlset>', {flag: 'as'});
+  async sitemapMapper(dir) {
+    var pathMap = this.buildPathMap(dir);
+    const exportPathMap = this.nextConfig && this.nextConfig.exportPathMap;
 
-    };
-
-    sitemapMapper(dir) {
-
-        let date = dateFns.format(new Date(), 'YYYY-MM-DD');
-        let data = fs.readdirSync(dir);
-        for (let site of data) {
-            if (site[0] === '_' || site[0] === '.') continue;
-            let toIgnore = false;
-            for (let path of this.ignoredPaths) {
-                if (site.includes(path)) toIgnore = true;
-            }
-            if (toIgnore) continue;
-
-            if (fs.lstatSync(dir + path.sep + site).isDirectory()) {
-                this.sitemapMapper(dir + path.sep + site);
-                continue;
-            }
-            let fileExtension = site.split('.').pop().length;
-            let fileNameWithoutExtension = site.substring(0, site.length - (fileExtension + 1));
-            fileNameWithoutExtension = this.ignoreIndexFiles && fileNameWithoutExtension === 'index' ? '' : fileNameWithoutExtension;
-            let newDir = dir.replace(this.pagesdirectory, '').replace(/\\/g, '/');
-            let alternates = '';
-            for (let langSite in this.alternatesUrls) {
-                alternates += `<xhtml:link rel="alernate" hreflang="${langSite}" href="${
-                    this.alternatesUrls[langSite]
-                    }${newDir + '/' + fileNameWithoutExtension}" />`;
-            }
-            let xmlObject = `<url><loc>${this.baseUrl}${newDir +
-                '/' +
-                fileNameWithoutExtension}</loc>` +
-                alternates +
-                `<lastmod>${date}</lastmod></url>`;
-            fs.writeFileSync(`${this.targetDirectory}${path.sep}sitemap.xml`, xmlObject, {flag: 'as'});
-        }
+    if (exportPathMap) {
+      pathMap = await exportPathMap(pathMap, {});
     }
 
+    const paths = Object.keys(pathMap);
+    const date = dateFns.format(new Date(), "YYYY-MM-DD");
+
+    for (var i = 0, len = paths.length; i < len; i++) {
+      let pagePath = paths[i];
+      let alternates = "";
+
+      for (let langSite in this.alternatesUrls) {
+        alternates += `<xhtml:link rel="alernate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${pagePath}" />`;
+      }
+
+      let xmlObject =
+        `<url><loc>${this.baseUrl}${pagePath}</loc>` +
+        alternates +
+        `<lastmod>${date}</lastmod></url>`;
+
+      fs.writeFileSync(
+        path.resolve(this.targetDirectory, "./sitemap.xml"),
+        xmlObject,
+        { flag: "as" }
+      );
+    }
+  }
 }
 
 module.exports = SiteMapper;
-

--- a/index.js
+++ b/index.js
@@ -1,16 +1,13 @@
+const Core = require("./core.js");
 
-const Core = require('./core.js');
+module.exports = async function(config) {
+  if (!config) {
+    throw new Error("Config is mandatory");
+  }
 
-module.exports = function (config) {
+  let coreMapper = new Core(config);
 
-    if (!config ) {
-        throw new Error('Config is mandatory');
-    }
-
-    let coreMapper = new Core(config);
-
-    coreMapper.preLaunch();
-    coreMapper.sitemapMapper(config.pagesDirectory);
-    coreMapper.finish();
-
-}
+  coreMapper.preLaunch();
+  await coreMapper.sitemapMapper(config.pagesDirectory);
+  coreMapper.finish();
+};


### PR DESCRIPTION
Added support for calling `exportPathMap` from the `next.config.js` file if the `nextConfigPath` is set
- Modified XML generation logic to first build a pathMap compatible with `exportPathMap` then generate xml off of that
- filesystem path logic cleanup
