### PR TITLE
Fix for `ignoreIndexFiles` when nesting the /index page via /index/index.js

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "printWidth": 90,
+    "semi": true,
+    "tabWidth": 4,
+    "useTabs": false,
+    "bracketSpacing": false
+}

--- a/core.js
+++ b/core.js
@@ -85,8 +85,7 @@ class SiteMapper {
             let toIgnoreExtension = false;
 
             for (let extensionToIgnore of this.ignoredExtensions) {
-                if (extensionToIgnore === fileExtension)
-                    toIgnoreExtension = true;
+                if (extensionToIgnore === fileExtension) toIgnoreExtension = true;
             }
 
             if (toIgnoreExtension) continue;
@@ -100,9 +99,7 @@ class SiteMapper {
                 this.ignoreIndexFiles && fileNameWithoutExtension === "index"
                     ? ""
                     : fileNameWithoutExtension;
-            let newDir = dir
-                .replace(this.pagesdirectory, "")
-                .replace(/\\/g, "/");
+            let newDir = dir.replace(this.pagesdirectory, "").replace(/\\/g, "/");
 
             if (this.ignoreIndexFiles && newDir === "/index") {
                 newDir = "";
@@ -144,7 +141,7 @@ class SiteMapper {
             fs.writeFileSync(
                 path.resolve(this.targetDirectory, "./sitemap.xml"),
                 xmlObject,
-                { flag: "as" }
+                {flag: "as"}
             );
         }
     }

--- a/core.js
+++ b/core.js
@@ -4,16 +4,16 @@ const path = require("path");
 
 class SiteMapper {
     constructor({
-                    alternateUrls,
-                    baseUrl,
-                    ignoreIndexFiles,
-                    ignoredPaths,
-                    pagesDirectory,
-                    sitemapPath,
-                    targetDirectory,
-                    nextConfigPath,
-                    ignoredExtensions
-                }) {
+        alternateUrls,
+        baseUrl,
+        ignoreIndexFiles,
+        ignoredPaths,
+        pagesDirectory,
+        sitemapPath,
+        targetDirectory,
+        nextConfigPath,
+        ignoredExtensions
+    }) {
         this.alternatesUrls = alternateUrls || {};
         this.baseUrl = baseUrl;
         this.ignoredPaths = ignoredPaths || [];
@@ -85,7 +85,8 @@ class SiteMapper {
             let toIgnoreExtension = false;
 
             for (let extensionToIgnore of this.ignoredExtensions) {
-                if (extensionToIgnore === fileExtension) toIgnoreExtension = true;
+                if (extensionToIgnore === fileExtension)
+                    toIgnoreExtension = true;
             }
 
             if (toIgnoreExtension) continue;
@@ -99,7 +100,13 @@ class SiteMapper {
                 this.ignoreIndexFiles && fileNameWithoutExtension === "index"
                     ? ""
                     : fileNameWithoutExtension;
-            let newDir = dir.replace(this.pagesdirectory, "").replace(/\\/g, "/");
+            let newDir = dir
+                .replace(this.pagesdirectory, "")
+                .replace(/\\/g, "/");
+
+            if (this.ignoreIndexFiles && newDir === "/index") {
+                newDir = "";
+            }
 
             let pagePath = newDir + "/" + fileNameWithoutExtension;
             pathMap[pagePath] = {
@@ -137,7 +144,7 @@ class SiteMapper {
             fs.writeFileSync(
                 path.resolve(this.targetDirectory, "./sitemap.xml"),
                 xmlObject,
-                {flag: "as"}
+                { flag: "as" }
             );
         }
     }


### PR DESCRIPTION
- Added a .prettierrc definition that matches the formatting decently