### PR TITLE
add support for exportTrailingSlash in Next config

### DIFF
--- a/core.js
+++ b/core.js
@@ -107,6 +107,7 @@ class SiteMapper {
     }
     async sitemapMapper(dir) {
         let pathMap = this.buildPathMap(dir);
+        const exportTrailingSlash = this.nextConfig && this.nextConfig.exportTrailingSlash;
         const exportPathMap = this.nextConfig && this.nextConfig.exportPathMap;
         if (exportPathMap) {
             try {
@@ -120,11 +121,15 @@ class SiteMapper {
         const date = date_fns_1.format(new Date(), 'yyyy-MM-dd');
         for (let i = 0, len = paths.length; i < len; i++) {
             const pagePath = paths[i];
+            let outputPath = paths[i];
+            if (exportTrailingSlash) {
+                outputPath += '/';
+            }
             let alternates = '';
             let priority = '';
             let changefreq = '';
             for (const langSite in this.alternatesUrls) {
-                alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${pagePath}" />`;
+                alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${outputPath}" />`;
             }
             if (this.pagesConfig && this.pagesConfig[pagePath.toLowerCase()]) {
                 const pageConfig = this.pagesConfig[pagePath];
@@ -135,7 +140,7 @@ class SiteMapper {
                     ? `<changefreq>${pageConfig.changefreq}</changefreq>`
                     : '';
             }
-            const xmlObject = `<url><loc>${this.baseUrl}${pagePath}</loc>
+            const xmlObject = `<url><loc>${this.baseUrl}${outputPath}</loc>
                 ${alternates}
                 ${priority}
                 ${changefreq}

--- a/core.js
+++ b/core.js
@@ -121,7 +121,7 @@ class SiteMapper {
         const date = date_fns_1.format(new Date(), 'yyyy-MM-dd');
         for (let i = 0, len = paths.length; i < len; i++) {
             const pagePath = paths[i];
-            let outputPath = paths[i];
+            let outputPath = pagePath;
             if (exportTrailingSlash) {
                 outputPath += '/';
             }

--- a/core.js
+++ b/core.js
@@ -105,7 +105,7 @@ class SiteMapper {
         }
         return pathMap;
     }
-    async sitemapMapper(dir) {
+    async getSitemapURLs(dir) {
         let pathMap = this.buildPathMap(dir);
         const exportTrailingSlash = this.nextConfig && this.nextConfig.exportTrailingSlash;
         const exportPathMap = this.nextConfig && this.nextConfig.exportPathMap;
@@ -118,29 +118,43 @@ class SiteMapper {
             }
         }
         const paths = Object.keys(pathMap);
-        const date = date_fns_1.format(new Date(), 'yyyy-MM-dd');
-        for (let i = 0, len = paths.length; i < len; i++) {
-            const pagePath = paths[i];
+        return paths.map(pagePath => {
             let outputPath = pagePath;
             if (exportTrailingSlash) {
                 outputPath += '/';
             }
+            let priority = '';
+            let changefreq = '';
+            if (this.pagesConfig && this.pagesConfig[pagePath.toLowerCase()]) {
+                const pageConfig = this.pagesConfig[pagePath];
+                priority = pageConfig.priority;
+                changefreq = pageConfig.changefreq;
+            }
+            return {
+                pagePath,
+                outputPath,
+                priority,
+                changefreq,
+            };
+        });
+    }
+    async sitemapMapper(dir) {
+        const urls = await this.getSitemapURLs(dir);
+        const date = date_fns_1.format(new Date(), 'yyyy-MM-dd');
+        urls.forEach((url) => {
             let alternates = '';
             let priority = '';
             let changefreq = '';
             for (const langSite in this.alternatesUrls) {
-                alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${outputPath}" />`;
+                alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${url.outputPath}" />`;
             }
-            if (this.pagesConfig && this.pagesConfig[pagePath.toLowerCase()]) {
-                const pageConfig = this.pagesConfig[pagePath];
-                priority = pageConfig.priority
-                    ? `<priority>${pageConfig.priority}</priority>`
-                    : '';
-                changefreq = pageConfig.changefreq
-                    ? `<changefreq>${pageConfig.changefreq}</changefreq>`
-                    : '';
+            if (url.priority) {
+                priority = `<priority>${url.priority}</priority>`;
             }
-            const xmlObject = `<url><loc>${this.baseUrl}${outputPath}</loc>
+            if (url.changefreq) {
+                changefreq = `<changefreq>${url.changefreq}</changefreq>`;
+            }
+            const xmlObject = `<url><loc>${this.baseUrl}${url.outputPath}</loc>
                 ${alternates}
                 ${priority}
                 ${changefreq}
@@ -149,7 +163,7 @@ class SiteMapper {
             fs_1.default.writeFileSync(path_1.default.resolve(this.targetDirectory, './sitemap.xml'), xmlObject, {
                 flag: 'as'
             });
-        }
+        });
     }
 }
 exports.default = SiteMapper;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "husky": "^4.0.6",
     "jest": "^24.9.0",
+    "mockdate": "^2.0.5",
     "prettier": "^1.19.1",
     "ts-jest": "^24.3.0",
     "typescript": "^3.7.4"

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -322,4 +322,36 @@ describe("with nextConfig", () => {
       ]
     `);
   });
+
+  it("should generate valid sitemap", async () => {
+    const core = getCoreWithNextConfig({
+      async exportPathMap(defaultMap) {
+        return {
+          "/exportPathMapURL": { page: "/" }
+        };
+      },
+      exportTrailingSlash: true
+    });
+
+    core.preLaunch();
+    await core.sitemapMapper(config.pagesDirectory);
+    core.finish();
+
+    const date = format(new Date(), "yyyy-MM-dd");
+    const sitemap = fs.readFileSync(
+      path.resolve(config.targetDirectory, "./sitemap.xml"),
+      { encoding: "UTF-8" }
+    );
+
+    expect(sitemap).toMatchInlineSnapshot(`
+      "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+      <urlset xsi:schemaLocation=\\"http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd\\" xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\">
+      <url><loc>https://example.com.ru/exportPathMapURL/</loc>
+                      <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/exportPathMapURL/\\" />
+                      
+                      
+                      <lastmod>2020-04-16</lastmod>
+                      </url></urlset>"
+    `);
+  });
 });

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -5,6 +5,7 @@ import Config from "./InterfaceConfig";
 import path from "path";
 import fs from "fs";
 import { format } from 'date-fns'
+import MockDate from "mockdate";
 
 const rootPath = path.resolve("./");
 
@@ -23,6 +24,14 @@ const config: Config = {
   ignoredExtensions: ["yml"]
 };
 const coreMapper = new Core(config);
+
+beforeEach(() => {
+  MockDate.set('2020-01-01T12:00:00Z');
+});
+
+afterAll(() => {
+  MockDate.reset();
+})
 
 it("Should detect reserved sites", () => {
   const underscoredSite = coreMapper.isReservedPage("_admin");
@@ -101,7 +110,6 @@ it("Should generate valid sitemap.xml", async () => {
   coreMapper.preLaunch();
   await coreMapper.sitemapMapper(config.pagesDirectory);
   coreMapper.finish();
-  const date = format(new Date(), 'yyyy-MM-dd')
   const sitemap = fs.readFileSync(
     path.resolve(config.targetDirectory, "./sitemap.xml"),
     { encoding: "UTF-8" }
@@ -114,57 +122,57 @@ it("Should generate valid sitemap.xml", async () => {
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/index.old\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/index.old\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/index.old\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/index.old\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url><url><loc>https://example.com.ru</loc>
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url><url><loc>https://example.com.ru/login</loc>
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/login\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/login\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/login\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/login\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url><url><loc>https://example.com.ru/product-discount</loc>
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/product-discount\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/product-discount\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/product-discount\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/product-discount\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url><url><loc>https://example.com.ru/set-user</loc>
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/set-user\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/set-user\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/set-user\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/set-user\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url><url><loc>https://example.com.ru/store/page1</loc>
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page1\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url><url><loc>https://example.com.ru/store/page2</loc>
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page2\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url><url><loc>https://example.com.ru/store/product/page1</loc>
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page1\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url><url><loc>https://example.com.ru/store/product/page2</loc>
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page2\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url><url><loc>https://example.com.ru/user/page1</loc>
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page1\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url><url><loc>https://example.com.ru/user/page2</loc>
                     <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page2\\" />
                     
                     
-                    <lastmod>${date}</lastmod>
+                    <lastmod>2020-01-01</lastmod>
                     </url></urlset>"
   `);
 });
@@ -350,7 +358,7 @@ describe("with nextConfig", () => {
                       <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/exportPathMapURL/\\" />
                       
                       
-                      <lastmod>2020-04-16</lastmod>
+                      <lastmod>2020-01-01</lastmod>
                       </url></urlset>"
     `);
   });

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -249,7 +249,7 @@ describe("with nextConfig", () => {
     const urls = await core.getSitemapURLs(config.pagesDirectory);
 
     const outputPaths = urls.map(url => url.outputPath);
-    expect(outputPaths.every(outputPath => outputPath.endsWith('/')));
+    expect(outputPaths.every(outputPath => outputPath.endsWith("/")));
 
     expect(urls).toMatchInlineSnapshot(`
       Array [

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -224,7 +224,6 @@ describe("with nextConfig", () => {
     const core = getCoreWithNextConfig({
       async exportPathMap(defaultMap) {
         return {
-          ...defaultMap,
           "/exportPathMapURL": { page: "/" }
         };
       }
@@ -232,10 +231,14 @@ describe("with nextConfig", () => {
 
     const urls = await core.getSitemapURLs(config.pagesDirectory);
 
-    const exportPathMapURL = urls.find(url => url.pagePath === '/exportPathMapURL');
-
-    expect(exportPathMapURL).toBeDefined();
-    expect(exportPathMapURL.outputPath).toEqual('/exportPathMapURL');
+    expect(urls).toEqual([
+      {
+        "changefreq": "",
+        "outputPath": "/exportPathMapURL",
+        "pagePath": "/exportPathMapURL",
+        "priority": ""
+      }
+    ]);
   });
 
   it("should respect exportTrailingSlash from Next config", async () => {

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -210,3 +210,113 @@ it("Should make map of sites", () => {
     }
   `);
 });
+
+describe("with nextConfig", () => {
+  function getCoreWithNextConfig(nextConfig) {
+    const core = new Core(config);
+
+    core.nextConfig = nextConfig;
+
+    return core;
+  }
+
+  it("should call exportPathMap from Next config", async () => {
+    const core = getCoreWithNextConfig({
+      async exportPathMap(defaultMap) {
+        return {
+          ...defaultMap,
+          "/exportPathMapURL": { page: "/" }
+        };
+      }
+    });
+
+    const urls = await core.getSitemapURLs(config.pagesDirectory);
+
+    const exportPathMapURL = urls.find(url => url.pagePath === '/exportPathMapURL');
+
+    expect(exportPathMapURL).toBeDefined();
+    expect(exportPathMapURL.outputPath).toEqual('/exportPathMapURL');
+  });
+
+  it("should respect exportTrailingSlash from Next config", async () => {
+    const core = getCoreWithNextConfig({
+      exportTrailingSlash: true
+    });
+
+    const urls = await core.getSitemapURLs(config.pagesDirectory);
+
+    const outputPaths = urls.map(url => url.outputPath);
+    expect(outputPaths.every(outputPath => outputPath.endsWith('/')));
+
+    expect(urls).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "changefreq": "",
+          "outputPath": "/index.old/",
+          "pagePath": "/index.old",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/",
+          "pagePath": "",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/login/",
+          "pagePath": "/login",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/product-discount/",
+          "pagePath": "/product-discount",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/set-user/",
+          "pagePath": "/set-user",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/store/page1/",
+          "pagePath": "/store/page1",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/store/page2/",
+          "pagePath": "/store/page2",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/store/product/page1/",
+          "pagePath": "/store/product/page1",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/store/product/page2/",
+          "pagePath": "/store/product/page2",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/user/page1/",
+          "pagePath": "/user/page1",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/user/page2/",
+          "pagePath": "/user/page2",
+          "priority": "",
+        },
+      ]
+    `);
+  });
+});

--- a/src/core.ts
+++ b/src/core.ts
@@ -153,8 +153,9 @@ class SiteMapper {
 
   async sitemapMapper (dir) {
     let pathMap = this.buildPathMap(dir)
-    const exportPathMap = this.nextConfig && this.nextConfig.exportPathMap
+    const exportTrailingSlash = this.nextConfig && this.nextConfig.exportTrailingSlash
 
+    const exportPathMap = this.nextConfig && this.nextConfig.exportPathMap
     if (exportPathMap) {
       try {
         pathMap = await exportPathMap(pathMap, {})
@@ -168,12 +169,17 @@ class SiteMapper {
 
     for (let i = 0, len = paths.length; i < len; i++) {
       const pagePath = paths[i]
+      let outputPath = paths[i]
+      if (exportTrailingSlash) {
+        outputPath += '/'
+      }
+
       let alternates = ''
       let priority = ''
       let changefreq = ''
 
       for (const langSite in this.alternatesUrls) {
-        alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${pagePath}" />`
+        alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${outputPath}" />`
       }
 
       if (this.pagesConfig && this.pagesConfig[pagePath.toLowerCase()]) {
@@ -186,7 +192,7 @@ class SiteMapper {
           : ''
       }
 
-      const xmlObject = `<url><loc>${this.baseUrl}${pagePath}</loc>
+      const xmlObject = `<url><loc>${this.baseUrl}${outputPath}</loc>
                 ${alternates}
                 ${priority}
                 ${changefreq}

--- a/src/core.ts
+++ b/src/core.ts
@@ -169,7 +169,7 @@ class SiteMapper {
 
     for (let i = 0, len = paths.length; i < len; i++) {
       const pagePath = paths[i]
-      let outputPath = paths[i]
+      let outputPath = pagePath
       if (exportTrailingSlash) {
         outputPath += '/'
       }


### PR DESCRIPTION
It appears that part of the fix in https://github.com/IlusionDev/nextjs-sitemap-generator/pull/28 got lost in https://github.com/IlusionDev/nextjs-sitemap-generator/pull/32.

This brings it back, but implemented slightly differently: the trailing slash is only appended to the sitemap output (rather than in `buildPathMap`/`pathMap`). `pathMap` is passed to `exportPathMap` (if present), which does not expect trailing slashes (Next.js does not pass trailing slashes when it invokes it as part of the original build, even with `exportTrailingSlash: true`).