### PR TITLE
improve ignoredPaths filtering (support filtering exportPathMap paths, match filter against full path)

### DIFF
--- a/core.js
+++ b/core.js
@@ -75,13 +75,9 @@ class SiteMapper {
         let pathMap = {};
         const data = fs_1.default.readdirSync(dir);
         for (const site of data) {
-            // Filter directories
             if (this.isReservedPage(site))
                 continue;
-            let toIgnore = false;
-            toIgnore = this.isIgnoredPath(site);
-            if (toIgnore)
-                continue;
+            // Filter directories
             const nextPath = dir + path_1.default.sep + site;
             if (fs_1.default.lstatSync(nextPath).isDirectory()) {
                 pathMap = {
@@ -121,6 +117,9 @@ class SiteMapper {
         const date = date_fns_1.format(new Date(), 'yyyy-MM-dd');
         for (let i = 0, len = paths.length; i < len; i++) {
             const pagePath = paths[i];
+            if (this.isIgnoredPath(pagePath)) {
+                continue;
+            }
             let outputPath = pagePath;
             if (exportTrailingSlash) {
                 outputPath += '/';

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -433,7 +433,13 @@ describe("with nextConfig", () => {
 
     expect(sitemap).toMatchInlineSnapshot(`
       "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
-      <urlset xsi:schemaLocation=\\"http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd\\" xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\">
+            <urlset xsi:schemaLocation=\\"http://www.sitemaps.org/schemas/sitemap/0.9 
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd\\" 
+            xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" 
+            xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" 
+            xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\">
+            <?xml-stylesheet type=\\"text/css\\" href=\\"/test/styles.css\\"?>
+      <?xml-stylesheet type=\\"text/xsl\\" href=\\"test/test/styles.xls\\"?>
       </urlset>"
     `);
   });

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -426,7 +426,6 @@ describe("with nextConfig", () => {
     await core.sitemapMapper(config.pagesDirectory);
     core.finish();
 
-    const date = format(new Date(), "yyyy-MM-dd");
     const sitemap = fs.readFileSync(
       path.resolve(config.targetDirectory, "./sitemap.xml"),
       { encoding: "UTF-8" }

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -177,6 +177,21 @@ it("Should make map of sites", () => {
       "": Object {
         "page": "",
       },
+      "/admin/page1": Object {
+        "page": "/admin/page1",
+      },
+      "/admin/page2": Object {
+        "page": "/admin/page2",
+      },
+      "/admin/page3": Object {
+        "page": "/admin/page3",
+      },
+      "/admin/superadmins/page1": Object {
+        "page": "/admin/superadmins/page1",
+      },
+      "/admin/superadmins/page2": Object {
+        "page": "/admin/superadmins/page2",
+      },
       "/index.old": Object {
         "page": "/index.old",
       },
@@ -253,6 +268,36 @@ describe("with nextConfig", () => {
 
     expect(urls).toMatchInlineSnapshot(`
       Array [
+        Object {
+          "changefreq": "",
+          "outputPath": "/admin/page1/",
+          "pagePath": "/admin/page1",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/admin/page2/",
+          "pagePath": "/admin/page2",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/admin/page3/",
+          "pagePath": "/admin/page3",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/admin/superadmins/page1/",
+          "pagePath": "/admin/superadmins/page1",
+          "priority": "",
+        },
+        Object {
+          "changefreq": "",
+          "outputPath": "/admin/superadmins/page2/",
+          "pagePath": "/admin/superadmins/page2",
+          "priority": "",
+        },
         Object {
           "changefreq": "",
           "outputPath": "/index.old/",

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -372,6 +372,7 @@ describe("with nextConfig", () => {
     const core = getCoreWithNextConfig({
       async exportPathMap(defaultMap) {
         return {
+          "/admin/": { page: "/" }, // should be filtered out by ignoredPaths
           "/exportPathMapURL": { page: "/" }
         };
       },

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -376,11 +376,37 @@ describe("with nextConfig", () => {
     `);
   });
 
+  it("should exclude ignoredPaths returned by exportPathMap", async () => {
+    const core = getCoreWithNextConfig({
+      async exportPathMap(defaultMap) {
+        return {
+          "/admin/": { page: "/" } // should be filtered out by ignoredPaths
+        };
+      },
+      exportTrailingSlash: true
+    });
+
+    core.preLaunch();
+    await core.sitemapMapper(config.pagesDirectory);
+    core.finish();
+
+    const date = format(new Date(), "yyyy-MM-dd");
+    const sitemap = fs.readFileSync(
+      path.resolve(config.targetDirectory, "./sitemap.xml"),
+      { encoding: "UTF-8" }
+    );
+
+    expect(sitemap).toMatchInlineSnapshot(`
+      "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+      <urlset xsi:schemaLocation=\\"http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd\\" xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\">
+      </urlset>"
+    `);
+  });
+
   it("should generate valid sitemap", async () => {
     const core = getCoreWithNextConfig({
       async exportPathMap(defaultMap) {
         return {
-          "/admin/": { page: "/" }, // should be filtered out by ignoredPaths
           "/exportPathMapURL": { page: "/" }
         };
       },

--- a/src/core.ts
+++ b/src/core.ts
@@ -116,13 +116,10 @@ class SiteMapper {
     const data = fs.readdirSync(dir)
 
     for (const site of data) {
-      // Filter directories
       if (this.isReservedPage(site)) continue
-      let toIgnore: boolean = false
-      toIgnore = this.isIgnoredPath(site)
-      if (toIgnore) continue
-      const nextPath: string = dir + path.sep + site
 
+      // Filter directories
+      const nextPath: string = dir + path.sep + site
       if (fs.lstatSync(nextPath).isDirectory()) {
         pathMap = {
           ...pathMap,
@@ -169,6 +166,11 @@ class SiteMapper {
 
     for (let i = 0, len = paths.length; i < len; i++) {
       const pagePath = paths[i]
+
+      if (this.isIgnoredPath(pagePath)) {
+        continue
+      }
+
       let outputPath = pagePath
       if (exportTrailingSlash) {
         outputPath += '/'


### PR DESCRIPTION
I ran into two issues with the current `ignoredPaths` filtering:
- it doesn't apply to pages from `exportPathMap`:  the filtering is only applied in `buildPathMap`, which gets called before `exportPathMap` adds paths
- because it is applied during directory traversal, the `ignoredPaths` are only matched against filenames, rather than the full path. This can make it hard to filter pages more specifically.
  - example: if you have a URL structure like:
    ```
    /pageA
    /subdir/pageA
    /subdir/pageB
    ```
     and you only want to exclude `/subdir/pageA`, the existing filtering mechanism doesn't let you. You either have to filter on `pageA` or `subdir`, and both will filter out the two matching paths.

This PR addresses those by making two changes:
1. refactor to move the filtering logic to after `exportPathMap` is called
  - I had to modify the snapshots for a couple of tests (45aa58a440fb00c07060208a9c5eaed6fec5c621) because they were testing the `buildPathMap` output specifically (which now doesn't apply filtering)
1. because the filtering logic is now applied later, it is now applied to the full path, rather than just filenames at each level of the path. This means that you can add e.g. `subdir/pageA` (from example above) to `ignoredPaths` to filter out only that specific page.

There is a chance that this second behaviour change affects the output for existing users, but I think that should only be the case if their existing `ignoredPath` does not match any paths (because this is loosening the filtering criteria). I think it should probably be fine to make this change with release notes, but it might merit a major version bump?