### PR TITLE
Add hardcoded path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ After generating the output files, run `node your_nextjs_sitemap_generator.js` t
  - **baseUrl**:  The url that it's going to be used at the beginning of each page.
  - **ignoreIndexFiles**: Whether index file should be in URL or just directory ending with the slash (OPTIONAL)
  - **ignoredPaths**:  File or directory to not map (like admin routes).(OPTIONAL)
- - **ignoredPaths**:  Array of extra paths to include in the sitemap (even if not present in pagesDirectory) (OPTIONAL)
+ - **extraPaths**:  Array of extra paths to include in the sitemap (even if not present in pagesDirectory) (OPTIONAL)
  - **ignoredExtensions**:  Ignore files by extension.(OPTIONAL)
  - **pagesDirectory**:  The directory where Nextjs pages live. You can use another directory while they are nextjs pages. **It must to be an absolute path**.
  - **targetDirectory**:  The directory where sitemap.xml going to be written.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ After generating the output files, run `node your_nextjs_sitemap_generator.js` t
 	      fr: 'https://example.fr',  
       },  
       baseUrl: 'https://example.com',  
-      ignoredPaths: ['admin'],  
+      ignoredPaths: ['admin'],
+      extraPaths: ['/extraPath'],
       pagesDirectory: __dirname + "\\pages",  
       targetDirectory : 'static/',
       nextConfigPath: __dirname + "\\next.config.js",
@@ -50,6 +51,7 @@ After generating the output files, run `node your_nextjs_sitemap_generator.js` t
  - **baseUrl**:  The url that it's going to be used at the beginning of each page.
  - **ignoreIndexFiles**: Whether index file should be in URL or just directory ending with the slash (OPTIONAL)
  - **ignoredPaths**:  File or directory to not map (like admin routes).(OPTIONAL)
+ - **ignoredPaths**:  Array of extra paths to include in the sitemap (even if not present in pagesDirectory) (OPTIONAL)
  - **ignoredExtensions**:  Ignore files by extension.(OPTIONAL)
  - **pagesDirectory**:  The directory where Nextjs pages live. You can use another directory while they are nextjs pages. **It must to be an absolute path**.
  - **targetDirectory**:  The directory where sitemap.xml going to be written.

--- a/core.js
+++ b/core.js
@@ -7,11 +7,12 @@ const fs_1 = __importDefault(require("fs"));
 const date_fns_1 = require("date-fns");
 const path_1 = __importDefault(require("path"));
 class SiteMapper {
-    constructor({ alternateUrls, baseUrl, ignoreIndexFiles, ignoredPaths, pagesDirectory, targetDirectory, nextConfigPath, ignoredExtensions, pagesConfig }) {
+    constructor({ alternateUrls, baseUrl, extraPaths, ignoreIndexFiles, ignoredPaths, pagesDirectory, targetDirectory, nextConfigPath, ignoredExtensions, pagesConfig }) {
         this.pagesConfig = pagesConfig || {};
         this.alternatesUrls = alternateUrls || {};
         this.baseUrl = baseUrl;
         this.ignoredPaths = ignoredPaths || [];
+        this.extraPaths = extraPaths || [];
         this.ignoreIndexFiles = ignoreIndexFiles || false;
         this.ignoredExtensions = ignoredExtensions || [];
         this.pagesdirectory = pagesDirectory;
@@ -113,7 +114,7 @@ class SiteMapper {
                 console.log(err);
             }
         }
-        const paths = Object.keys(pathMap);
+        const paths = Object.keys(pathMap).concat(this.extraPaths);
         return paths.map(pagePath => {
             let outputPath = pagePath;
             if (exportTrailingSlash) {

--- a/src/InterfaceConfig.ts
+++ b/src/InterfaceConfig.ts
@@ -2,6 +2,7 @@ export default interface Config {
   alternateUrls?: object;
   baseUrl: string;
   ignoredPaths?: Array<string>;
+  extraPaths?: Array<string>;
   ignoreIndexFiles?: Array<string> | boolean;
   ignoredExtensions?: Array<string>;
   pagesDirectory: string;

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -106,6 +106,22 @@ it("Should generate sitemap.xml", async () => {
   expect(sitemap.size).toBeGreaterThan(0);
 });
 
+it("should add extraPaths to output", async () => {
+  const core = new Core({
+    ...config,
+    extraPaths: ['/extraPath'],
+  });
+
+  const urls = await core.getSitemapURLs(config.pagesDirectory);
+
+  expect(urls).toContainEqual({
+    pagePath: '/extraPath',
+    outputPath: '/extraPath',
+    priority: '',
+    changefreq: '',
+  });
+});
+
 it("Should generate valid sitemap.xml", async () => {
   coreMapper.preLaunch();
   await coreMapper.sitemapMapper(config.pagesDirectory);

--- a/src/core.ts
+++ b/src/core.ts
@@ -13,6 +13,8 @@ class SiteMapper {
 
   ignoredPaths?: Array<string>;
 
+  extraPaths?: Array<string>;
+
   ignoreIndexFiles?: Array<string> | boolean;
 
   ignoredExtensions?: Array<string>;
@@ -32,6 +34,7 @@ class SiteMapper {
   constructor ({
     alternateUrls,
     baseUrl,
+    extraPaths,
     ignoreIndexFiles,
     ignoredPaths,
     pagesDirectory,
@@ -44,6 +47,7 @@ class SiteMapper {
     this.alternatesUrls = alternateUrls || {}
     this.baseUrl = baseUrl
     this.ignoredPaths = ignoredPaths || []
+    this.extraPaths = extraPaths || []
     this.ignoreIndexFiles = ignoreIndexFiles || false
     this.ignoredExtensions = ignoredExtensions || []
     this.pagesdirectory = pagesDirectory
@@ -161,7 +165,7 @@ class SiteMapper {
       }
     }
 
-    const paths = Object.keys(pathMap)
+    const paths = Object.keys(pathMap).concat(this.extraPaths)
 
     return paths.map(pagePath => {
       let outputPath = pagePath


### PR DESCRIPTION
Adds an `extraPaths` param to the config which allows adding hardcoded entries to the sitemap.