### PR TITLE
Feature: custom sitemap filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 /node_modules
 package-lock.json
+example/static/main.xml

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ sitemap({
   extraPaths: ['/extraPath'],
   pagesDirectory: __dirname + "\\pages",
   targetDirectory : 'static/',
+  sitemapFilename: 'sitemap.xml',
   nextConfigPath: __dirname + "\\next.config.js",
   ignoredExtensions: [
         'png',
@@ -73,6 +74,7 @@ console.log(`✅ sitemap.xml generated!`);
  - **ignoredExtensions**:  Ignore files by extension.(OPTIONAL)
  - **pagesDirectory**:  The directory where Nextjs pages live. You can use another directory while they are nextjs pages. **It must to be an absolute path**.
  - **targetDirectory**:  The directory where sitemap.xml going to be written.
+ - **sitemapFilename**:  The filename for the sitemap. Defaults to `sitemap.xml`. (OPTIONAL)
  - **pagesConfig**:  Object configuration of priority and changefreq per route.(OPTIONAL)
  - **sitemapStylesheet**:  Array of style objects that will be applied to sitemap.(OPTIONAL)
  - **nextConfigPath**(Used for dynamic routes):  Calls `exportPathMap` if exported from `nextConfigPath` js file.

--- a/core.js
+++ b/core.js
@@ -7,7 +7,7 @@ const fs_1 = __importDefault(require("fs"));
 const date_fns_1 = require("date-fns");
 const path_1 = __importDefault(require("path"));
 class SiteMapper {
-    constructor({ alternateUrls, baseUrl, extraPaths, ignoreIndexFiles, ignoredPaths, pagesDirectory, targetDirectory, nextConfigPath, ignoredExtensions, pagesConfig, sitemapStylesheet }) {
+    constructor({ alternateUrls, baseUrl, extraPaths, ignoreIndexFiles, ignoredPaths, pagesDirectory, targetDirectory, sitemapFilename, nextConfigPath, ignoredExtensions, pagesConfig, sitemapStylesheet }) {
         this.pagesConfig = pagesConfig || {};
         this.alternatesUrls = alternateUrls || {};
         this.baseUrl = baseUrl;
@@ -17,6 +17,7 @@ class SiteMapper {
         this.ignoredExtensions = ignoredExtensions || [];
         this.pagesdirectory = pagesDirectory;
         this.targetDirectory = targetDirectory;
+        this.sitemapFilename = sitemapFilename || 'sitemap.xml';
         this.nextConfigPath = nextConfigPath;
         this.sitemapStylesheet = sitemapStylesheet || [];
         this.sitemapTag = `<?xml version="1.0" encoding="UTF-8"?>`;
@@ -39,12 +40,12 @@ class SiteMapper {
         if (this.sitemapStylesheet) {
             this.sitemapStylesheet.forEach(({ type, styleFile }) => { xmlStyle += `<?xml-stylesheet href="${styleFile}" type="${type}" ?>\n`; });
         }
-        fs_1.default.writeFileSync(path_1.default.resolve(this.targetDirectory, './sitemap.xml'), this.sitemapTag + xmlStyle + this.sitemapUrlSet, {
+        fs_1.default.writeFileSync(path_1.default.resolve(this.targetDirectory, './', this.sitemapFilename), this.sitemapTag + xmlStyle + this.sitemapUrlSet, {
             flag: 'w'
         });
     }
     finish() {
-        fs_1.default.writeFileSync(path_1.default.resolve(this.targetDirectory, './sitemap.xml'), '</urlset>', {
+        fs_1.default.writeFileSync(path_1.default.resolve(this.targetDirectory, './', this.sitemapFilename), '</urlset>', {
             flag: 'as'
         });
     }
@@ -168,7 +169,7 @@ class SiteMapper {
                 ${changefreq}
                 <lastmod>${date}</lastmod>
                 </url>`;
-            fs_1.default.writeFileSync(path_1.default.resolve(this.targetDirectory, './sitemap.xml'), xmlObject, {
+            fs_1.default.writeFileSync(path_1.default.resolve(this.targetDirectory, './', this.sitemapFilename), xmlObject, {
                 flag: 'as'
             });
         });

--- a/src/InterfaceConfig.ts
+++ b/src/InterfaceConfig.ts
@@ -12,6 +12,7 @@ export default interface Config {
   pagesDirectory: string;
   nextConfigPath?: string;
   targetDirectory: string;
+  sitemapFilename?: string;
   pagesConfig?: object;
   sitemapStylesheet?: Array<SitemapStyleFile>
 };

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -131,6 +131,21 @@ it("should add extraPaths to output", async () => {
   });
 });
 
+it("Should generate a sitemap with a custom file name", async () => {
+  const coreMapper = new Core({
+    ...config,
+    sitemapFilename: "main.xml",
+  });
+  coreMapper.preLaunch();
+  await coreMapper.sitemapMapper(config.pagesDirectory);
+  coreMapper.finish();
+  const sitemap = fs.statSync(
+    path.resolve(config.targetDirectory, "./main.xml")
+  );
+
+  expect(sitemap.size).toBeGreaterThan(0);
+});
+
 it("Should generate valid sitemap.xml", async () => {
   coreMapper.preLaunch();
   await coreMapper.sitemapMapper(config.pagesDirectory);

--- a/src/core.ts
+++ b/src/core.ts
@@ -33,6 +33,8 @@ class SiteMapper {
 
   targetDirectory: string;
 
+  sitemapFilename?: string;
+
   sitemapStylesheet?: Array<SitemapStyleFile>;
 
   constructor ({
@@ -43,6 +45,7 @@ class SiteMapper {
     ignoredPaths,
     pagesDirectory,
     targetDirectory,
+    sitemapFilename,
     nextConfigPath,
     ignoredExtensions,
     pagesConfig,
@@ -57,6 +60,7 @@ class SiteMapper {
     this.ignoredExtensions = ignoredExtensions || []
     this.pagesdirectory = pagesDirectory
     this.targetDirectory = targetDirectory
+    this.sitemapFilename = sitemapFilename || 'sitemap.xml'
     this.nextConfigPath = nextConfigPath
     this.sitemapStylesheet = sitemapStylesheet || []
     this.sitemapTag = `<?xml version="1.0" encoding="UTF-8"?>`
@@ -82,13 +86,13 @@ class SiteMapper {
     if (this.sitemapStylesheet) {
       this.sitemapStylesheet.forEach(({ type, styleFile }) => { xmlStyle += `<?xml-stylesheet href="${styleFile}" type="${type}" ?>\n` })
     }
-    fs.writeFileSync(path.resolve(this.targetDirectory, './sitemap.xml'), this.sitemapTag + xmlStyle + this.sitemapUrlSet, {
+    fs.writeFileSync(path.resolve(this.targetDirectory, './', this.sitemapFilename), this.sitemapTag + xmlStyle + this.sitemapUrlSet, {
       flag: 'w'
     })
   }
 
   finish () {
-    fs.writeFileSync(path.resolve(this.targetDirectory, './sitemap.xml'), '</urlset>', {
+    fs.writeFileSync(path.resolve(this.targetDirectory, './', this.sitemapFilename), '</urlset>', {
       flag: 'as'
     })
   }
@@ -237,7 +241,7 @@ class SiteMapper {
                 <lastmod>${date}</lastmod>
                 </url>`
 
-      fs.writeFileSync(path.resolve(this.targetDirectory, './sitemap.xml'), xmlObject, {
+      fs.writeFileSync(path.resolve(this.targetDirectory, './', this.sitemapFilename), xmlObject, {
         flag: 'as'
       })
     })


### PR DESCRIPTION
This will allow for a name other than `sitemap.xml` for use cases where`<sitemapindex>` XML structure is used and links to a sitemap that this library generates.

See: https://www.sitemaps.org/protocol.html#index