### PR TITLE
Enable Regex in Pages Config

### DIFF
--- a/core.js
+++ b/core.js
@@ -149,7 +149,26 @@ class SiteMapper {
             }
             let priority = '';
             let changefreq = '';
-            if (this.pagesConfig && this.pagesConfig[pagePath.toLowerCase()]) {
+            if (!this.pagesConfig) {
+                return {
+                    pagePath,
+                    outputPath,
+                    priority,
+                    changefreq
+                };
+            }
+            // 1. Generic wildcard configs go first
+            Object.entries(this.pagesConfig).forEach(([key, val]) => {
+                if (key.includes("*")) {
+                    let regex = new RegExp(key, "i");
+                    if (regex.test(pagePath)) {
+                        priority = val.priority;
+                        changefreq = val.changefreq;
+                    }
+                }
+            });
+            // 2. Specific page config go second
+            if (this.pagesConfig[pagePath.toLowerCase()]) {
                 const pageConfig = this.pagesConfig[pagePath.toLowerCase()];
                 priority = pageConfig.priority;
                 changefreq = pageConfig.changefreq;

--- a/core.js
+++ b/core.js
@@ -186,24 +186,32 @@ class SiteMapper {
         const filteredURLs = urls.filter(url => !this.isIgnoredPath(url.pagePath));
         const date = date_fns_1.format(new Date(), 'yyyy-MM-dd');
         filteredURLs.forEach((url) => {
+            let xmlObject = `\n\t<url>`;
+            // Location
+            let location = `<loc>${this.baseUrl}${url.outputPath}</loc>`;
+            xmlObject = xmlObject.concat(`\n\t\t${location}`);
+            // Alternates
             let alternates = '';
-            let priority = '';
-            let changefreq = '';
             for (const langSite in this.alternatesUrls) {
                 alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${url.outputPath}" />`;
             }
+            if (alternates != '') {
+                xmlObject = xmlObject.concat(`\n\t\t${alternates}`);
+            }
+            // Priority
             if (url.priority) {
-                priority = `<priority>${url.priority}</priority>`;
+                let priority = `<priority>${url.priority}</priority>`;
+                xmlObject = xmlObject.concat(`\n\t\t${priority}`);
             }
+            // Change Frequency
             if (url.changefreq) {
-                changefreq = `<changefreq>${url.changefreq}</changefreq>`;
+                let changefreq = `<changefreq>${url.changefreq}</changefreq>`;
+                xmlObject = xmlObject.concat(`\n\t\t${changefreq}`);
             }
-            const xmlObject = `<url><loc>${this.baseUrl}${url.outputPath}</loc>
-                ${alternates}
-                ${priority}
-                ${changefreq}
-                <lastmod>${date}</lastmod>
-                </url>`;
+            // Last Modification
+            let lastmod = `<lastmod>${date}</lastmod>`;
+            xmlObject = xmlObject.concat(`\n\t\t${lastmod}`);
+            xmlObject = xmlObject.concat(`\n\t</url>\n`);
             fs_1.default.writeFileSync(path_1.default.resolve(this.targetDirectory, './', this.sitemapFilename), xmlObject, {
                 flag: 'as'
             });

--- a/example/static/sitemap.xml
+++ b/example/static/sitemap.xml
@@ -6,9 +6,10 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
       xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" 
       xmlns:xhtml="http://www.w3.org/1999/xhtml">
-      <url><loc>https://example.com.ru/exportPathMapURL/</loc>
-                <xhtml:link rel="alternate" hreflang="en" href="https://example.en/exportPathMapURL/" /><xhtml:link rel="alternate" hreflang="es" href="https://example.es/exportPathMapURL/" /><xhtml:link rel="alternate" hreflang="ja" href="https://example.jp/exportPathMapURL/" /><xhtml:link rel="alternate" hreflang="fr" href="https://example.fr/exportPathMapURL/" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url></urlset>
+      
+	<url>
+		<loc>https://example.com.ru/exportPathMapURL/</loc>
+		<xhtml:link rel="alternate" hreflang="en" href="https://example.en/exportPathMapURL/" /><xhtml:link rel="alternate" hreflang="es" href="https://example.es/exportPathMapURL/" /><xhtml:link rel="alternate" hreflang="ja" href="https://example.jp/exportPathMapURL/" /><xhtml:link rel="alternate" hreflang="fr" href="https://example.fr/exportPathMapURL/" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+</urlset>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Generate sitemap.xml from nextjs pages",
   "main": "index.js",
   "scripts": {
-    "test": "yarn jest && tsc"
+    "test": "yarn jest && tsc",
+    "tsc": "tsc"
   },
   "keywords": [
     "nextjs",

--- a/src/__snapshots__/core.test.ts.snap
+++ b/src/__snapshots__/core.test.ts.snap
@@ -9,62 +9,73 @@ exports[`Core testing Should generate valid sitemap.xml 1`] = `
       xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" 
       xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" 
       xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\">
-      <url><loc>https://example.com.ru/index.old</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/index.old\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/index.old\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/index.old\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/index.old\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/login</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/login\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/login\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/login\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/login\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/product-discount</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/product-discount\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/product-discount\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/product-discount\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/product-discount\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/set-user</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/set-user\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/set-user\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/set-user\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/set-user\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/store/page1</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page1\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/store/page2</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page2\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/store/product/page1</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page1\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/store/product/page2</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page2\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/user/page1</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page1\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/user/page2</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page2\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url></urlset>"
+      
+	<url>
+		<loc>https://example.com.ru/index.old</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/index.old\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/index.old\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/index.old\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/index.old\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/login</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/login\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/login\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/login\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/login\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/product-discount</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/product-discount\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/product-discount\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/product-discount\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/product-discount\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/set-user</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/set-user\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/set-user\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/set-user\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/set-user\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/page1</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page1\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/page2</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page2\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/product/page1</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page1\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/product/page2</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page2\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/user/page1</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page1\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page1\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/user/page2</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page2\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page2\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+</urlset>"
 `;
 
 exports[`Core testing Should make map of sites 1`] = `
@@ -129,62 +140,73 @@ exports[`Core testing Should match the snapshot if allowFileExtensions 1`] = `
       xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" 
       xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" 
       xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\">
-      <url><loc>https://example.com.ru/index.old.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/index.old.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/index.old.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/index.old.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/index.old.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/index.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/index.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/index.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/index.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/index.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/login.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/login.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/login.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/login.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/login.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/product-discount.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/product-discount.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/product-discount.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/product-discount.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/product-discount.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/set-user.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/set-user.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/set-user.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/set-user.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/set-user.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/store/page1.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page1.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/store/page2.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page2.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/store/product/page1.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page1.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/store/product/page2.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page2.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/user/page1.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page1.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url><url><loc>https://example.com.ru/user/page2.tsx</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page2.tsx\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url></urlset>"
+      
+	<url>
+		<loc>https://example.com.ru/index.old.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/index.old.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/index.old.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/index.old.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/index.old.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/index.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/index.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/index.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/index.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/index.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/login.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/login.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/login.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/login.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/login.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/product-discount.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/product-discount.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/product-discount.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/product-discount.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/product-discount.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/set-user.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/set-user.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/set-user.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/set-user.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/set-user.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/page1.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page1.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/page2.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page2.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/product/page1.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page1.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/product/page2.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page2.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/user/page1.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page1.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/user/page2.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page2.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+</urlset>"
 `;
 
 exports[`TestCore with nextConfig should exclude ignoredPaths returned by exportPathMap 1`] = `
@@ -208,12 +230,13 @@ exports[`TestCore with nextConfig should generate valid sitemap 1`] = `
       xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" 
       xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" 
       xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\">
-      <url><loc>https://example.com.ru/exportPathMapURL/</loc>
-                <xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/exportPathMapURL/\\" />
-                
-                
-                <lastmod>2020-01-01</lastmod>
-                </url></urlset>"
+      
+	<url>
+		<loc>https://example.com.ru/exportPathMapURL/</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/exportPathMapURL/\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/exportPathMapURL/\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+</urlset>"
 `;
 
 exports[`TestCore with nextConfig should respect exportTrailingSlash from Next config 1`] = `

--- a/src/__snapshots__/core.test.ts.snap
+++ b/src/__snapshots__/core.test.ts.snap
@@ -209,6 +209,84 @@ exports[`Core testing Should match the snapshot if allowFileExtensions 1`] = `
 </urlset>"
 `;
 
+exports[`Core testing Should use regex in pagesConfig 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><?xml-stylesheet href=\\"/test/styles.css\\" type=\\"text/css\\" ?>
+<?xml-stylesheet href=\\"test/test/styles.xls\\" type=\\"text/xsl\\" ?>
+
+      <urlset xsi:schemaLocation=\\"http://www.sitemaps.org/schemas/sitemap/0.9 
+      http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd\\" 
+      xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" 
+      xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" 
+      xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\">
+      
+	<url>
+		<loc>https://example.com.ru/index.old.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/index.old.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/index.old.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/index.old.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/index.old.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/index.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/index.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/index.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/index.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/index.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/login.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/login.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/login.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/login.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/login.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/product-discount.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/product-discount.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/product-discount.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/product-discount.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/product-discount.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/set-user.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/set-user.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/set-user.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/set-user.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/set-user.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/page1.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page1.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/page2.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/page2.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/product/page1.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page1.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/store/product/page2.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/store/product/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/store/product/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/store/product/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/store/product/page2.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/user/page1.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page1.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page1.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+
+	<url>
+		<loc>https://example.com.ru/user/page2.tsx</loc>
+		<xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.en/user/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"es\\" href=\\"https://example.es/user/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"ja\\" href=\\"https://example.jp/user/page2.tsx\\" /><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.fr/user/page2.tsx\\" />
+		<lastmod>2020-01-01</lastmod>
+	</url>
+</urlset>"
+`;
+
 exports[`TestCore with nextConfig should exclude ignoredPaths returned by exportPathMap 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><?xml-stylesheet href=\\"/test/styles.css\\" type=\\"text/css\\" ?>
 <?xml-stylesheet href=\\"test/test/styles.xls\\" type=\\"text/xsl\\" ?>
@@ -314,16 +392,16 @@ Array [
     "priority": "",
   },
   Object {
-    "changefreq": "",
+    "changefreq": "weekly",
     "outputPath": "/store/product/page1/",
     "pagePath": "/store/product/page1",
-    "priority": "",
+    "priority": "0.6",
   },
   Object {
-    "changefreq": "",
+    "changefreq": "weekly",
     "outputPath": "/store/product/page2/",
     "pagePath": "/store/product/page2",
-    "priority": "",
+    "priority": "0.6",
   },
   Object {
     "changefreq": "",

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -223,8 +223,29 @@ describe("Core testing", () => {
 
     expect(sitemap).toMatchSnapshot();
   });
-  
-  
+
+  it('Should use regex in pagesConfig', async () => {
+    const core = new Core({
+      ...config,
+      allowFileExtensions: true,
+    });
+    config.pagesConfig = {
+      "/store/product/*": {
+        priority: "0.6",
+        changefreq: "weekly"
+      },
+    }
+    core.preLaunch();
+    await core.sitemapMapper(config.pagesDirectory);
+    core.finish();
+
+    const sitemap = fs.readFileSync(
+      path.resolve(config.targetDirectory, "./sitemap.xml"),
+      { encoding: "UTF-8" }
+    );
+
+    expect(sitemap).toMatchSnapshot();
+  });
 })
 
 describe("TestCore with nextConfig", () => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -11,7 +11,7 @@ class SiteMapper {
 
   baseUrl: string;
 
-  ignoredPaths?: Array<string|RegExp>;
+  ignoredPaths?: Array<string | RegExp>;
 
   extraPaths?: Array<string>;
 
@@ -88,17 +88,27 @@ class SiteMapper {
     let xmlStyle = ''
 
     if (this.sitemapStylesheet) {
-      this.sitemapStylesheet.forEach(({ type, styleFile }) => { xmlStyle += `<?xml-stylesheet href="${styleFile}" type="${type}" ?>\n` })
+      this.sitemapStylesheet.forEach(({ type, styleFile }) => {
+        xmlStyle += `<?xml-stylesheet href="${styleFile}" type="${type}" ?>\n`
+      })
     }
-    fs.writeFileSync(path.resolve(this.targetDirectory, './', this.sitemapFilename), this.sitemapTag + xmlStyle + this.sitemapUrlSet, {
-      flag: 'w'
-    })
+    fs.writeFileSync(
+      path.resolve(this.targetDirectory, './', this.sitemapFilename),
+      this.sitemapTag + xmlStyle + this.sitemapUrlSet,
+      {
+        flag: 'w'
+      }
+    )
   }
 
   finish () {
-    fs.writeFileSync(path.resolve(this.targetDirectory, './', this.sitemapFilename), '</urlset>', {
-      flag: 'as'
-    })
+    fs.writeFileSync(
+      path.resolve(this.targetDirectory, './', this.sitemapFilename),
+      '</urlset>',
+      {
+        flag: 'as'
+      }
+    )
   }
 
   isReservedPage (site: string): boolean {
@@ -163,8 +173,14 @@ class SiteMapper {
       const fileExtension = site.split('.').pop()
       if (this.isIgnoredExtension(fileExtension)) continue
 
-      let fileNameWithoutExtension = site.substring(0, site.length - (fileExtension.length + 1))
-      fileNameWithoutExtension = this.ignoreIndexFiles && fileNameWithoutExtension === 'index' ? '' : fileNameWithoutExtension
+      let fileNameWithoutExtension = site.substring(
+        0,
+        site.length - (fileExtension.length + 1)
+      )
+      fileNameWithoutExtension =
+        this.ignoreIndexFiles && fileNameWithoutExtension === 'index'
+          ? ''
+          : fileNameWithoutExtension
 
       let newDir = dir.replace(this.pagesdirectory, '').replace(/\\/g, '/')
 
@@ -185,7 +201,10 @@ class SiteMapper {
     const { exportTrailingSlash, trailingSlash } = this.nextConfig
     const next9OrlowerVersion = typeof exportTrailingSlash !== 'undefined'
     const next10Version = typeof trailingSlash !== 'undefined'
-    if ((next9OrlowerVersion || next10Version) && (exportTrailingSlash || trailingSlash)) return true
+    if (
+      (next9OrlowerVersion || next10Version) &&
+      (exportTrailingSlash || trailingSlash)
+    ) { return true }
 
     return false
   }
@@ -206,7 +225,7 @@ class SiteMapper {
 
     const paths = Object.keys(pathMap).concat(this.extraPaths)
 
-    return paths.map(pagePath => {
+    return paths.map((pagePath) => {
       let outputPath = pagePath
       if (exportTrailingSlash && !this.allowFileExtensions) {
         outputPath += '/'
@@ -217,27 +236,27 @@ class SiteMapper {
 
       if (!this.pagesConfig) {
         return {
-            pagePath,
-            outputPath,
-            priority,
-            changefreq
-        };
+          pagePath,
+          outputPath,
+          priority,
+          changefreq
+        }
       }
 
       // 1. Generic wildcard configs go first
-      Object.entries(this.pagesConfig).forEach(([key,val]) => {
-          if (key.includes("*")) {
-              let regex = new RegExp(key, "i");
-              if (regex.test(pagePath)) {
-                  priority = val.priority;
-                  changefreq = val.changefreq;
-              }
+      Object.entries(this.pagesConfig).forEach(([key, val]) => {
+        if (key.includes('*')) {
+          const regex = new RegExp(key, 'i')
+          if (regex.test(pagePath)) {
+            priority = val.priority
+            changefreq = val.changefreq
           }
+        }
       })
 
-       // 2. Specific page config go second
+      // 2. Specific page config go second
       if (this.pagesConfig[pagePath.toLowerCase()]) {
-        const pageConfig = this.pagesConfig[pagePath.toLowerCase()];
+        const pageConfig = this.pagesConfig[pagePath.toLowerCase()]
         priority = pageConfig.priority
         changefreq = pageConfig.changefreq
       }
@@ -254,47 +273,53 @@ class SiteMapper {
   async sitemapMapper (dir) {
     const urls = await this.getSitemapURLs(dir)
 
-    const filteredURLs = urls.filter(url => !this.isIgnoredPath(url.pagePath))
+    const filteredURLs = urls.filter(
+      (url) => !this.isIgnoredPath(url.pagePath)
+    )
 
     const date = format(new Date(), 'yyyy-MM-dd')
 
     filteredURLs.forEach((url) => {
-      let xmlObject = `\n\t<url>`;
+      let xmlObject = '\n\t<url>'
 
       // Location
-      let location = `<loc>${this.baseUrl}${url.outputPath}</loc>`;
-      xmlObject = xmlObject.concat(`\n\t\t${location}`);
+      const location = `<loc>${this.baseUrl}${url.outputPath}</loc>`
+      xmlObject = xmlObject.concat(`\n\t\t${location}`)
 
       // Alternates
-      let alternates = '';
+      let alternates = ''
       for (const langSite in this.alternatesUrls) {
-          alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${url.outputPath}" />`;
+        alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${url.outputPath}" />`
       }
-      if (alternates != '') {
-          xmlObject = xmlObject.concat(`\n\t\t${alternates}`);
+      if (alternates !== '') {
+        xmlObject = xmlObject.concat(`\n\t\t${alternates}`)
       }
 
       // Priority
       if (url.priority) {
-          let priority = `<priority>${url.priority}</priority>`;
-          xmlObject = xmlObject.concat(`\n\t\t${priority}`);
+        const priority = `<priority>${url.priority}</priority>`
+        xmlObject = xmlObject.concat(`\n\t\t${priority}`)
       }
 
       // Change Frequency
       if (url.changefreq) {
-          let changefreq = `<changefreq>${url.changefreq}</changefreq>`;
-          xmlObject = xmlObject.concat(`\n\t\t${changefreq}`);
+        const changefreq = `<changefreq>${url.changefreq}</changefreq>`
+        xmlObject = xmlObject.concat(`\n\t\t${changefreq}`)
       }
 
       // Last Modification
-      let lastmod = `<lastmod>${date}</lastmod>`;
-      xmlObject = xmlObject.concat(`\n\t\t${lastmod}`);
+      const lastmod = `<lastmod>${date}</lastmod>`
+      xmlObject = xmlObject.concat(`\n\t\t${lastmod}`)
 
-      xmlObject = xmlObject.concat(`\n\t</url>\n`);
+      xmlObject = xmlObject.concat('\n\t</url>\n')
 
-      fs.writeFileSync(path.resolve(this.targetDirectory, './', this.sitemapFilename), xmlObject, {
-        flag: 'as'
-      })
+      fs.writeFileSync(
+        path.resolve(this.targetDirectory, './', this.sitemapFilename),
+        xmlObject,
+        {
+          flag: 'as'
+        }
+      )
     })
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -210,7 +210,28 @@ class SiteMapper {
       let priority = ''
       let changefreq = ''
 
-      if (this.pagesConfig && this.pagesConfig[pagePath.toLowerCase()]) {
+      if (!this.pagesConfig) {
+        return {
+            pagePath,
+            outputPath,
+            priority,
+            changefreq
+        };
+      }
+
+      // 1. Generic wildcard configs go first
+      Object.entries(this.pagesConfig).forEach(([key,val]) => {
+          if (key.includes("*")) {
+              let regex = new RegExp(key, "i");
+              if (regex.test(pagePath)) {
+                  priority = val.priority;
+                  changefreq = val.changefreq;
+              }
+          }
+      })
+
+       // 2. Specific page config go second
+      if (this.pagesConfig[pagePath.toLowerCase()]) {
         const pageConfig = this.pagesConfig[pagePath.toLowerCase()];
         priority = pageConfig.priority
         changefreq = pageConfig.changefreq

--- a/src/core.ts
+++ b/src/core.ts
@@ -254,27 +254,38 @@ class SiteMapper {
     const date = format(new Date(), 'yyyy-MM-dd')
 
     filteredURLs.forEach((url) => {
-      let alternates = ''
-      let priority = ''
-      let changefreq = ''
+      let xmlObject = `\n\t<url>`;
 
+      // Location
+      let location = `<loc>${this.baseUrl}${url.outputPath}</loc>`;
+      xmlObject = xmlObject.concat(`\n\t\t${location}`);
+
+      // Alternates
+      let alternates = '';
       for (const langSite in this.alternatesUrls) {
-        alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${url.outputPath}" />`
+          alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${url.outputPath}" />`;
+      }
+      if (alternates != '') {
+          xmlObject = xmlObject.concat(`\n\t\t${alternates}`);
       }
 
+      // Priority
       if (url.priority) {
-        priority = `<priority>${url.priority}</priority>`
-      }
-      if (url.changefreq) {
-        changefreq = `<changefreq>${url.changefreq}</changefreq>`
+          let priority = `<priority>${url.priority}</priority>`;
+          xmlObject = xmlObject.concat(`\n\t\t${priority}`);
       }
 
-      const xmlObject = `<url><loc>${this.baseUrl}${url.outputPath}</loc>
-                ${alternates}
-                ${priority}
-                ${changefreq}
-                <lastmod>${date}</lastmod>
-                </url>`
+      // Change Frequency
+      if (url.changefreq) {
+          let changefreq = `<changefreq>${url.changefreq}</changefreq>`;
+          xmlObject = xmlObject.concat(`\n\t\t${changefreq}`);
+      }
+
+      // Last Modification
+      let lastmod = `<lastmod>${date}</lastmod>`;
+      xmlObject = xmlObject.concat(`\n\t\t${lastmod}`);
+
+      xmlObject = xmlObject.concat(`\n\t</url>\n`);
 
       fs.writeFileSync(path.resolve(this.targetDirectory, './', this.sitemapFilename), xmlObject, {
         flag: 'as'

--- a/src/core.ts
+++ b/src/core.ts
@@ -243,7 +243,6 @@ class SiteMapper {
         }
       }
 
-      // 1. Generic wildcard configs go first
       Object.entries(this.pagesConfig).forEach(([key, val]) => {
         if (key.includes('*')) {
           const regex = new RegExp(key, 'i')
@@ -254,7 +253,6 @@ class SiteMapper {
         }
       })
 
-      // 2. Specific page config go second
       if (this.pagesConfig[pagePath.toLowerCase()]) {
         const pageConfig = this.pagesConfig[pagePath.toLowerCase()]
         priority = pageConfig.priority
@@ -282,36 +280,29 @@ class SiteMapper {
     filteredURLs.forEach((url) => {
       let xmlObject = '\n\t<url>'
 
-      // Location
       const location = `<loc>${this.baseUrl}${url.outputPath}</loc>`
-      xmlObject = xmlObject.concat(`\n\t\t${location}`)
+      xmlObject += `\n\t\t${location}`
 
-      // Alternates
       let alternates = ''
       for (const langSite in this.alternatesUrls) {
         alternates += `<xhtml:link rel="alternate" hreflang="${langSite}" href="${this.alternatesUrls[langSite]}${url.outputPath}" />`
       }
       if (alternates !== '') {
-        xmlObject = xmlObject.concat(`\n\t\t${alternates}`)
+        xmlObject += `\n\t\t${alternates}`
       }
 
-      // Priority
       if (url.priority) {
         const priority = `<priority>${url.priority}</priority>`
-        xmlObject = xmlObject.concat(`\n\t\t${priority}`)
+        xmlObject += `\n\t\t${priority}`
       }
 
-      // Change Frequency
       if (url.changefreq) {
         const changefreq = `<changefreq>${url.changefreq}</changefreq>`
-        xmlObject = xmlObject.concat(`\n\t\t${changefreq}`)
+        xmlObject += `\n\t\t${changefreq}`
       }
 
-      // Last Modification
       const lastmod = `<lastmod>${date}</lastmod>`
-      xmlObject = xmlObject.concat(`\n\t\t${lastmod}`)
-
-      xmlObject = xmlObject.concat('\n\t</url>\n')
+      xmlObject += `\n\t\t${lastmod}\n\t</url>\n`
 
       fs.writeFileSync(
         path.resolve(this.targetDirectory, './', this.sitemapFilename),


### PR DESCRIPTION
Hi Team,

This is a **preliminary** PR to get some thoughts to implement regex on pagesConfig to work on https://github.com/IlusionDev/nextjs-sitemap-generator/issues/50

There are a few different strategies and I am not sure which one you would like to take, if you'd like to have a priority order, etc.

Happy to hear feedback, then, write test.

An example of configuration:

```
    pagesConfig: {
      // Daily
      "/posts": {
        priority: "0.5",
        changefreq: "daily"
      },
      "/posts/.*": {
        priority: "0.5",
        changefreq: "daily"
      },
```